### PR TITLE
Fix for LogManager.GetCurrentClassLogger not creating loggers properly for constructors

### DIFF
--- a/src/Common.Logging/Logging/LogManager.cs
+++ b/src/Common.Logging/Logging/LogManager.cs
@@ -202,6 +202,16 @@ namespace Common.Logging
             StackFrame frame = new StackFrame(1, false);
             ILoggerFactoryAdapter adapter = Adapter;
             MethodBase method = frame.GetMethod();
+            MethodBase upperMethod = method;
+            for(var offset = 2; ; offset++)
+            {
+                if((upperMethod == null) || !upperMethod.IsConstructor)
+                {
+                    break;
+                }
+                method = upperMethod;
+                upperMethod = new StackFrame(offset, false).GetMethod();
+            }
             Type declaringType = method.DeclaringType;
             return adapter.GetLogger(declaringType);
         }


### PR DESCRIPTION
LogManager.GetCurrentClassLogger() did not honor calls from constructors of inherited classes. For example, if you had two classes as follows:

```
class A
{
    protected ILog log = LogManager.GetCurrentClassLogger();

    public DoSomething()
    {
        log.Info("Doing something...");
    }
}

class B : A
{
}

A a = new A();
B b = new B();

a.DoSomething();
b.DoSomething();
```

the both calls for "a" and "b" objects would log the message for the same logger (class A) which is not expected. This commit fixes this issue and creates different loggers for objects of descendent classes.
