### PR TITLE
tags to help search find packages as per https://github.com/net-commons/...

### DIFF
--- a/src/Common.Logging.EntLib31/Common.Logging.EntLib31.nuspec
+++ b/src/Common.Logging.EntLib31/Common.Logging.EntLib31.nuspec
@@ -13,6 +13,7 @@
     <dependencies>
       <dependency id="Common.Logging" version="2.0.0" />
     </dependencies>
+	<tags>entlib common logging</tags>
   </metadata>
   <files>
     <file src="..\..\build\net20\Common.Logging.EntLib31\Release\Common.Logging.Entlib31.dll" target="lib\net35" />

--- a/src/Common.Logging.EntLib41/Common.Logging.EntLib41.nuspec
+++ b/src/Common.Logging.EntLib41/Common.Logging.EntLib41.nuspec
@@ -13,6 +13,7 @@
     <dependencies>
       <dependency id="Common.Logging" version="2.0.0" />
     </dependencies>
+	<tags>entlib common logging</tags>
   </metadata>
   <files>
     <file src="..\..\build\net20\Common.Logging.EntLib41\Release\Common.Logging.Entlib41.dll" target="lib\net35" />

--- a/src/Common.Logging.EntLib50/Common.Logging.EntLib50.nuspec
+++ b/src/Common.Logging.EntLib50/Common.Logging.EntLib50.nuspec
@@ -13,6 +13,7 @@
     <dependencies>
       <dependency id="Common.Logging" version="2.0.0" />
     </dependencies>
+	<tags>entlib common logging</tags>
   </metadata>
   <files>
     <file src="..\..\build\net20\Common.Logging.EntLib50\Release\Common.Logging.Entlib50.dll" target="lib\net35" />

--- a/src/Common.Logging.EntLib60/Common.Logging.EntLib60.nuspec
+++ b/src/Common.Logging.EntLib60/Common.Logging.EntLib60.nuspec
@@ -15,6 +15,7 @@
       <dependency id="EnterpriseLibrary.Common" version="6.0.1304" />
       <dependency id="EnterpriseLibrary.Logging" version="6.0.1304" />
     </dependencies>
+	<tags>entlib common logging</tags>
   </metadata>
   <files>
     <file src="..\..\build\net45\Common.Logging.EntLib60\Release\Common.Logging.Entlib60.dll" target="lib\net45" />

--- a/src/Common.Logging.Log4Net1210/Common.Logging.Log4Net1210.nuspec
+++ b/src/Common.Logging.Log4Net1210/Common.Logging.Log4Net1210.nuspec
@@ -10,6 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Common.Logging library bindings for Log4Net 1.2.10 logging framework.</description>
     <language>en-US</language>
+	<tags>log4net common logging</tags>
     <dependencies>
       <dependency id="Common.Logging" version="2.0.0" />
       <dependency id="log4net" version="[1.2.10]" />

--- a/src/Common.Logging.Log4Net1211/Common.Logging.Log4Net1211.nuspec
+++ b/src/Common.Logging.Log4Net1211/Common.Logging.Log4Net1211.nuspec
@@ -10,6 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Common.Logging library bindings for Log4Net 1.2.11 logging framework.</description>
     <language>en-US</language>
+	<tags>log4net common logging</tags>
     <dependencies>
       <dependency id="Common.Logging" version="2.0.0" />
       <dependency id="Log4Net" version="1.2.11" />

--- a/src/Common.Logging.Log4Net1212/Common.Logging.Log4Net1212.nuspec
+++ b/src/Common.Logging.Log4Net1212/Common.Logging.Log4Net1212.nuspec
@@ -10,6 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Common.Logging library bindings for Log4Net 1.2.12 logging framework.</description>
     <language>en-US</language>
+	<tags>log4net common logging</tags>
     <dependencies>
       <dependency id="Common.Logging" version="2.0.0" />
       <dependency id="Log4Net" version="1.2.12" />

--- a/src/Common.Logging.Log4Net1213/Common.Logging.Log4Net1213.nuspec
+++ b/src/Common.Logging.Log4Net1213/Common.Logging.Log4Net1213.nuspec
@@ -10,6 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Common.Logging library bindings for Log4Net 1.2.13 logging framework.</description>
     <language>en-US</language>
+	<tags>log4net common logging</tags>
     <dependencies>
       <dependency id="Common.Logging" version="2.0.0" />
       <dependency id="Log4Net" version="1.2.13" />

--- a/src/Common.Logging.Log4Net129/Common.Logging.Log4Net129.nuspec
+++ b/src/Common.Logging.Log4Net129/Common.Logging.Log4Net129.nuspec
@@ -10,6 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Common.Logging library bindings for Log4Net 1.2.9 logging framework.</description>
     <language>en-US</language>
+	<tags>log4net common logging</tags>
     <dependencies>
       <dependency id="Common.Logging" version="2.0.0" />
     </dependencies>

--- a/src/Common.Logging.NLog10/Common.Logging.NLog10.nuspec
+++ b/src/Common.Logging.NLog10/Common.Logging.NLog10.nuspec
@@ -10,6 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Common.Logging library bindings for NLog 1.0 logging framework.</description>
     <language>en-US</language>
+	<tags>nlog common logging</tags>
     <dependencies>
       <dependency id="Common.Logging" version="2.0.0" />
       <dependency id="NLog" version="[1.0.0]" />

--- a/src/Common.Logging.NLog20/Common.Logging.NLog20.nuspec
+++ b/src/Common.Logging.NLog20/Common.Logging.NLog20.nuspec
@@ -10,6 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Common.Logging library bindings for NLog 2.0 logging framework.</description>
     <language>en-US</language>
+	<tags>nlog common logging</tags>
     <dependencies>
       <dependency id="Common.Logging" version="2.0.0" />
       <dependency id="NLog" version="2.0.0" />

--- a/src/Common.Logging.NLog21/Common.Logging.NLog21.nuspec
+++ b/src/Common.Logging.NLog21/Common.Logging.NLog21.nuspec
@@ -10,6 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Common.Logging library bindings for NLog 2.1 logging framework.</description>
     <language>en-US</language>
+	<tags>nlog common logging</tags>
     <dependencies>
       <dependency id="Common.Logging" version="2.0.0" />
       <dependency id="NLog" version="2.1.0" />

--- a/src/Common.Logging.NLog30/Common.Logging.NLog30.nuspec
+++ b/src/Common.Logging.NLog30/Common.Logging.NLog30.nuspec
@@ -10,6 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Common.Logging library bindings for NLog 3.0 logging framework.</description>
     <language>en-US</language>
+	<tags>nlog common logging</tags>
     <dependencies>
       <dependency id="Common.Logging" version="2.2.0" />
       <dependency id="NLog" version="3.0.0" />

--- a/src/Common.Logging.NLog31/Common.Logging.NLog31.nuspec
+++ b/src/Common.Logging.NLog31/Common.Logging.NLog31.nuspec
@@ -10,6 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Common.Logging library bindings for NLog 3.1 logging framework.</description>
     <language>en-US</language>
+	<tags>nlog common logging</tags>
     <dependencies>
       <dependency id="Common.Logging" version="2.2.0" />
       <dependency id="NLog" version="3.1.0" />


### PR DESCRIPTION
have added tags to nuspec packages as suggested in [strategy 4a](https://github.com/net-commons/common-logging/wiki/NuGet-Packaging-Update-Strategies)

should help nuget searchers find the current packages
