### PR TITLE
pr: fixed bug when logging exception with indexer property

### DIFF
--- a/src/Common.Logging.Portable/Logging/Simple/ExceptionFormatter.cs
+++ b/src/Common.Logging.Portable/Logging/Simple/ExceptionFormatter.cs
@@ -169,7 +169,13 @@ namespace Common.Logging.Simple
 
                 Object propertyValue = "<unavailable>";
                 if (property.CanRead)
-                    propertyValue = property.GetValue(exception, null);
+                {
+                    //if property is indexer, has no idea how to output that,
+                    //and, also, without second param GetValue throw error in this case
+                    //so, simple skip this
+                    if (property.GetIndexParameters().Length <= 0)
+                        propertyValue = property.GetValue(exception, null);
+                }
 
                 var enumerableValue = propertyValue as IEnumerable;
 

--- a/test/Common.Logging.Tests/Common.Logging.Tests.2010-net40.csproj
+++ b/test/Common.Logging.Tests/Common.Logging.Tests.2010-net40.csproj
@@ -73,6 +73,7 @@
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Logging\Factory\AbstractLoggerTests.cs" />
     <Compile Include="ExceptionsTest.cs" />
+    <Compile Include="Logging\LoggingExceptionWithIndexerBugTest.cs" />
     <Compile Include="Logging\LogLevelNumericComparisonTests.cs" />
     <Compile Include="Logging\Simple\CapturingLoggerTests.cs" />
     <Compile Include="Logging\Simple\CommonLoggingTraceListenerTests.cs" />

--- a/test/Common.Logging.Tests/Logging/LoggingExceptionWithIndexerBugTest.cs
+++ b/test/Common.Logging.Tests/Logging/LoggingExceptionWithIndexerBugTest.cs
@@ -1,0 +1,53 @@
+﻿#region License
+
+/*
+ * Copyright © 2002-2007 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+using System;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Common.Logging
+{
+    /// <summary>
+    /// Exception with indexer property should be logged without <see cref="TargetParameterCountException"/> error
+    /// </summary>
+    /// <author>artem1</author>
+    /// <version>$Id:$</version>
+    public class LoggingExceptionWithIndexerBugTest
+    {
+        /// <summary>
+        /// This bug was found by me in Npgsql driver for PostgreSQL (NpgsqlException)
+        /// </summary>
+        [Test]
+        public void ErrorNotThrownWhenLoggedExceptionHasIndexerProperty()
+        {
+            ILog log = LogManager.GetCurrentClassLogger();
+            ExceptionWithIndexer exception = new ExceptionWithIndexer();
+            Assert.That(() => log.Error("error catched", exception), Throws.Nothing);
+        }
+        
+        public class ExceptionWithIndexer : Exception
+        {
+            public string this[string key]
+            {
+                get { return null; }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Try to fix bug with exception logging, when ex contains indexer property
repro in LoggingExceptionWithIndexerBugTest
