### PR TITLE
Added TypeForwardedToAttribute

### DIFF
--- a/src/Common.Logging.Portable/AssemblyInfo.cs
+++ b/src/Common.Logging.Portable/AssemblyInfo.cs
@@ -1,4 +1,15 @@
 
+using System.Runtime.CompilerServices;
+
+using Common.Logging;
+
 [assembly: System.Reflection.AssemblyProduct("Common Logging Framework")]
 [assembly: System.Security.SecurityTransparent]
 
+[assembly: TypeForwardedTo(typeof(FormatMessageHandler))]
+[assembly: TypeForwardedTo(typeof(IConfigurationReader))]
+[assembly: TypeForwardedTo(typeof(ILog))]
+[assembly: TypeForwardedTo(typeof(ILoggerFactoryAdapter))]
+[assembly: TypeForwardedTo(typeof(ILogManager))]
+[assembly: TypeForwardedTo(typeof(IVariablesContext))]
+[assembly: TypeForwardedTo(typeof(LogLevel))]


### PR DESCRIPTION
Added TypeForwardedToAttribute for types that were moved to
Common.Logging.Core, so that callers which were compiled against 2.x
will work with 3.x without recompiling