### PR TITLE
Create ApplicationInsightsLoggerFactoryAdapter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,22 @@ The app config should then have a common logging section like below. Be sure to 
 </nlog>
 ```
 
+## Application Insights Quickstart
+There are different packages for each major Application Insights version. Install the correct package for your referenced Application Insights version. This example installs the adapter for Application Insights v0.17:
+
+    PM> Install-Package Microsoft.ApplicationInsights -Version 0.17.0
+
+The app config should then have an Application Insights section like below. Be sure to set the InstrumentationKey with your InstrumentationKey retrieved from Application Insights portal https://portal.azure.com.
+
+```xml
+<common>
+    <logging>
+      <factoryAdapter type="Common.Logging.ApplicationInsights.ApplicationInsightsLoggerFactoryAdapter, Common.Logging.ApplicationInsights">
+    	<arg key="InstrumentationKey" value="[YOUR APPLICATION INSIGHTS INSTRUMENTATION KEY]" />
+      </factoryAdapter>
+    </logging>
+</common>
+```
 
 See module documentation and [Source Forge](http://netcommon.sf.net/) for other factoryAdapters and their configuration values
 

--- a/src/Common.Logging.ApplicationInsights0170/AssemblyInfo.cs
+++ b/src/Common.Logging.ApplicationInsights0170/AssemblyInfo.cs
@@ -1,0 +1,15 @@
+﻿using System.Reflection;
+using System.Security;
+
+[assembly: AssemblyProduct("Common Logging Framework Application Insights Adapter")]
+
+// Application Insights does not allow Partially Trust Callers 
+// it cannot set [assembly: AllowPartiallyTrustedCallers()] attribute and therefore does not use
+// CommonAssemblyInfo.cs
+
+[assembly: AssemblyCompanyAttribute("http://netcommon.sourceforge.net/")]
+[assembly: AssemblyCopyrightAttribute("Copyright 2006-2011 the Common Infrastructure Libraries Team.")]
+[assembly: AssemblyTrademarkAttribute("Apache License, Version 2.0")]
+[assembly: AssemblyCultureAttribute("")]
+[assembly: AssemblyVersionAttribute("3.1.0")]
+[assembly: AssemblyDelaySignAttribute(false)]

--- a/src/Common.Logging.ApplicationInsights0170/Common.Logging.ApplicationInsights0170.csproj
+++ b/src/Common.Logging.ApplicationInsights0170/Common.Logging.ApplicationInsights0170.csproj
@@ -1,0 +1,75 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{039C6EB5-1B1A-4BDF-AB4D-E949844581C7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Common.Logging.ApplicationInsights</RootNamespace>
+    <AssemblyName>Common.Logging.ApplicationInsights</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.ApplicationInsights, Version=0.17.0.576, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.0.17.0\lib\net45\Microsoft.ApplicationInsights.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="Logging\ApplicationInsights\ApplicationInsightsLogger.cs" />
+    <Compile Include="Logging\ApplicationInsights\ApplicationInsightsLoggerFactoryAdapter.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Common.Logging.Core\Common.Logging.Core.2010-net20.csproj">
+      <Project>{cadfb630-279f-427c-96a9-d2f9aa718648}</Project>
+      <Name>Common.Logging.Core.2010-net20</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Common.Logging\Common.Logging.2010.csproj">
+      <Project>{440d903a-d409-48fc-a6c4-3ee69ccd663b}</Project>
+      <Name>Common.Logging.2010</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Common.Logging.ApplicationInsights0170/Logging/ApplicationInsights/ApplicationInsightsLogger.cs
+++ b/src/Common.Logging.ApplicationInsights0170/Logging/ApplicationInsights/ApplicationInsightsLogger.cs
@@ -1,0 +1,96 @@
+﻿#region License
+
+/*
+ * Copyright © 2002-2015 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+namespace Common.Logging.ApplicationInsights
+{
+    using Microsoft.ApplicationInsights;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using System;
+    using System.Text;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Sends log messages to Application Insights.
+    /// </summary>
+    /// <author>Mihail Smacinih</author>
+    public class ApplicationInsightsLogger : Simple.AbstractSimpleLogger
+    {
+        private static readonly List<KeyValuePair<LogLevel, SeverityLevel>> levelMap = new List<KeyValuePair<LogLevel, SeverityLevel>>();
+
+        static ApplicationInsightsLogger()
+        {
+            levelMap.Add(Create<LogLevel, SeverityLevel>(LogLevel.Fatal, SeverityLevel.Critical));
+            levelMap.Add(Create<LogLevel, SeverityLevel>(LogLevel.Error, SeverityLevel.Error));
+            levelMap.Add(Create<LogLevel, SeverityLevel>(LogLevel.Warn, SeverityLevel.Warning));
+            levelMap.Add(Create<LogLevel, SeverityLevel>(LogLevel.Info, SeverityLevel.Information));
+            levelMap.Add(Create<LogLevel, SeverityLevel>(LogLevel.Debug, SeverityLevel.Verbose));
+            levelMap.Add(Create<LogLevel, SeverityLevel>(LogLevel.Trace, SeverityLevel.Verbose));
+            levelMap.Add(Create<LogLevel, SeverityLevel>(LogLevel.All, SeverityLevel.Verbose));
+        }
+
+        public readonly TelemetryClient telemetryClient;
+
+        public ApplicationInsightsLogger(string instrumentationKey, string logName, LogLevel logLevel, bool showlevel, bool showDateTime, bool showLogName, string dateTimeFormat)
+            : base(logName, logLevel, showlevel, showDateTime, showLogName, dateTimeFormat)
+        {
+            this.telemetryClient = new TelemetryClient();
+            this.telemetryClient.Context.InstrumentationKey = instrumentationKey;
+        }
+
+        protected override void WriteInternal(LogLevel level, object message, Exception exception)
+        {
+            if (level.HasFlag(LogLevel.Off)) 
+            {
+                return;
+            }
+
+            StringBuilder sb = new StringBuilder();
+            FormatOutput(sb, level, message, exception);
+
+            SeverityLevel severityLevel = ConvertToSeverityLevel(level);
+            this.telemetryClient.TrackTrace(sb.ToString(), severityLevel);
+
+            if (exception != null)
+            {
+                this.telemetryClient.TrackException(exception);
+            }
+        }
+
+        private static SeverityLevel ConvertToSeverityLevel(LogLevel logLevel)
+        {
+            SeverityLevel result = SeverityLevel.Verbose;
+            foreach (var kv in levelMap) 
+            {
+                if (logLevel.HasFlag(kv.Key)) 
+                {
+                    result = kv.Value;
+                    break;
+                }
+            }
+
+            return result;
+        }
+
+        private static KeyValuePair<K, V> Create<K, V>(K key, V value)
+        {
+            return new KeyValuePair<K, V>(key, value);
+        }
+    }
+}

--- a/src/Common.Logging.ApplicationInsights0170/Logging/ApplicationInsights/ApplicationInsightsLoggerFactoryAdapter.cs
+++ b/src/Common.Logging.ApplicationInsights0170/Logging/ApplicationInsights/ApplicationInsightsLoggerFactoryAdapter.cs
@@ -1,0 +1,94 @@
+﻿#region License
+
+/*
+ * Copyright © 2002-2015 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+namespace Common.Logging.ApplicationInsights
+{
+    using Common.Logging.Configuration;
+    using System;
+
+    /// <summary>
+    /// Concrete subclass of ILoggerFactoryAdapter specific to ApplicationInsights.
+    /// </summary>
+    /// <remarks>
+    /// The following configuration property values must be configured:
+    /// <list type="bullet">
+    ///     <item><c>InstrumentationKey</c>: <c>Application Insights InstrumentationKey</c></item>
+    /// </list>
+    /// </remarks>
+    /// <example>
+    /// The following snippet shows how to configure ApplicationInsights logging for Common.Logging:
+    /// <code>
+    /// &lt;configuration&gt;
+    ///   &lt;configSections&gt;
+    ///       &lt;section name=&quot;logging&quot; type=&quot;Common.Logging.ConfigurationSectionHandler, Common.Logging&quot; /&gt;
+    ///   &lt;/configSections&gt;
+    ///   &lt;common&gt;
+    ///     &lt;logging&gt;
+    ///       &lt;factoryAdapter type=&quot;Common.Logging.ApplicationInsights.ApplicationInsightsLoggerFactoryAdapter, Common.Logging.ApplicationInsights&quot;&gt;
+    ///         &lt;arg key=&quot;InstrumentationKey&quot; value=&quot;[InstrumentationKey]&quot; /&gt;
+    ///       &lt;/factoryAdapter&gt;
+    ///     &lt;/logging&gt;
+    ///   &lt;/common&gt;
+    /// &lt;/configuration&gt;
+    /// </code>
+    /// </example>
+    /// <author>Mihail Smacinih</author>
+    public class ApplicationInsightsLoggerFactoryAdapter : Simple.AbstractSimpleLoggerFactoryAdapter
+    {
+        private readonly string instrumentationKey;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApplicationInsightsLoggerFactoryAdapter"/> class.
+        /// </summary>
+        /// <remarks>
+        /// Looks for level, showDateTime, showLogName, dateTimeFormat items from 
+        /// <paramref name="properties" /> for use when the GetLogger methods are called.
+        /// <see cref="ConfigurationSectionHandler"/> for more information on how to use the 
+        /// standard .NET application configuraiton file (App.config/Web.config) 
+        /// to configure this adapter.
+        /// </remarks>
+        /// <param name="properties">The name value collection, typically specified by the user in 
+        /// a configuration section named common/logging.</param>
+        public ApplicationInsightsLoggerFactoryAdapter(NameValueCollection properties)
+            : base(properties)
+        {
+            if (properties == null)
+            {
+                throw new ArgumentNullException("properties argument is null");
+            }
+
+            if (properties["InstrumentationKey"] == null)
+            {
+                throw new ArgumentException("InstrumentationKey property is not specified");
+            }
+
+            this.instrumentationKey = properties["InstrumentationKey"];
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ILog"/> instance.
+        /// </summary>
+        protected override ILog CreateLogger(string name, LogLevel level, bool showLevel, bool showDateTime, bool showLogName, string dateTimeFormat)
+        {
+            ILog log = new ApplicationInsightsLogger(instrumentationKey, name, level, showLevel, showDateTime, showLogName, dateTimeFormat);
+            return log;
+        }
+    }
+}

--- a/src/Common.Logging.ApplicationInsights0170/packages.config
+++ b/src/Common.Logging.ApplicationInsights0170/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.ApplicationInsights" version="0.17.0" targetFramework="net45" />
+</packages>

--- a/test/Common.Logging.ApplicationInsights0170.Tests/Common.Logging.ApplicationInsights0170.Tests.csproj
+++ b/test/Common.Logging.ApplicationInsights0170.Tests/Common.Logging.ApplicationInsights0170.Tests.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9202E384-BA52-4AE8-8D1A-9059E3BCA2EC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Common.Logging.ApplicationInsights.Tests</RootNamespace>
+    <AssemblyName>Common.Logging.ApplicationInsights.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Logging\ApplicationInsights\ApplicationInsightsLoggerFactoryAdapterTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Common.Logging.ApplicationInsights0170\Common.Logging.ApplicationInsights0170.csproj">
+      <Project>{039c6eb5-1b1a-4bdf-ab4d-e949844581c7}</Project>
+      <Name>Common.Logging.ApplicationInsights0170</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Common.Logging.Core\Common.Logging.Core.2010-net20.csproj">
+      <Project>{cadfb630-279f-427c-96a9-d2f9aa718648}</Project>
+      <Name>Common.Logging.Core.2010-net20</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Common.Logging\Common.Logging.2010.csproj">
+      <Project>{440d903a-d409-48fc-a6c4-3ee69ccd663b}</Project>
+      <Name>Common.Logging.2010</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/test/Common.Logging.ApplicationInsights0170.Tests/Logging/ApplicationInsights/ApplicationInsightsLoggerFactoryAdapterTests.cs
+++ b/test/Common.Logging.ApplicationInsights0170.Tests/Logging/ApplicationInsights/ApplicationInsightsLoggerFactoryAdapterTests.cs
@@ -1,0 +1,138 @@
+﻿#region License
+
+/*
+ * Copyright 2002-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+namespace Common.Logging.ApplicationInsights.Tests
+{
+    using Common.Logging.ApplicationInsights;
+    using Common.Logging.Configuration;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+
+    /// <summary>
+    /// </summary>
+    /// <author>Mihail Smacinih</author>
+    [TestClass]
+    public class ApplicationInsightsLoggerFactoryAdapterTests
+    {
+        [Owner("Mihail Smacinih")]
+        [TestMethod]
+        public void LogMessageAndException()
+        {
+            TestApplicationInsightsLoggerFactoryAdapter a = CreateTestApplicationInsightsLoggerFactoryAdapter();
+            Exception ex = new Exception("errormessage");
+
+            ILog log = a.GetLogger(this.GetType());
+            log.Error("Message2", ex);
+            Assert.AreEqual("Message2", a.LastLogEntry.Message);
+            Assert.AreEqual(ex, a.LastLogEntry.Exception);
+            Assert.AreEqual(LogLevel.Error, a.LastLogEntry.LogLevel);
+        }
+
+        [Owner("Mihail Smacinih")]
+        [TestMethod]
+        public void LogMessage()
+        {
+            TestApplicationInsightsLoggerFactoryAdapter a = CreateTestApplicationInsightsLoggerFactoryAdapter();
+
+            ILog log = a.GetLogger(this.GetType());
+            log.Info("Message2");
+            Assert.AreEqual("Message2", a.LastLogEntry.Message);
+            Assert.IsNull(a.LastLogEntry.Exception);
+            Assert.AreEqual(LogLevel.Info, a.LastLogEntry.LogLevel);
+        }
+
+        [Owner("Mihail Smacinih")]
+        [TestMethod]
+        public void LogDebug()
+        {
+            TestApplicationInsightsLoggerFactoryAdapter a = CreateTestApplicationInsightsLoggerFactoryAdapter();
+            ILog log = a.GetLogger(this.GetType());
+            Exception ex = new Exception("errormessage3");
+            log.Debug(null, ex);
+            Assert.AreEqual(ex, a.LastLogEntry.Exception);
+            Assert.AreEqual(LogLevel.Debug, a.LastLogEntry.LogLevel);
+        }
+
+        [Owner("Mihail Smacinih")]
+        [TestMethod]
+        public void LogException()
+        {
+            TestApplicationInsightsLoggerFactoryAdapter a = CreateTestApplicationInsightsLoggerFactoryAdapter();
+            ILog log = a.GetLogger(this.GetType());
+            Exception ex = new Exception("errormessage3");
+            log.Error(null, ex);
+            Assert.AreEqual(ex, a.LastLogEntry.Exception);
+            Assert.AreEqual(LogLevel.Error, a.LastLogEntry.LogLevel);
+        }
+
+        private static TestApplicationInsightsLoggerFactoryAdapter CreateTestApplicationInsightsLoggerFactoryAdapter()
+        {
+            return new TestApplicationInsightsLoggerFactoryAdapter("7227BA1E-F6E4-4149-A776-94CC0F4D57C4");
+        }
+
+        private class TestApplicationInsightsLoggerFactoryAdapter: ApplicationInsightsLoggerFactoryAdapter
+        {
+            private readonly string instrumentationKey;
+            
+            public TestApplicationInsightsLoggerFactoryAdapter(string instrumentationKey) 
+                : base(new NameValueCollection() { {"InstrumentationKey", instrumentationKey.ToString()} })
+            {
+                this.instrumentationKey = instrumentationKey;
+            }
+
+            public LogEntry LastLogEntry { get; set; }
+
+            protected override ILog CreateLogger(string name, LogLevel level, bool showLevel, bool showDateTime, bool showLogName, string dateTimeFormat)
+            {
+                return new TestApplicationInsightsLogger(this, instrumentationKey, name, level, showLevel, showDateTime, showLogName, dateTimeFormat);
+            }
+
+            public class TestApplicationInsightsLogger : ApplicationInsightsLogger
+            {
+                private TestApplicationInsightsLoggerFactoryAdapter owner;
+                public TestApplicationInsightsLogger(TestApplicationInsightsLoggerFactoryAdapter owner, string instrumentationKey, string logName, LogLevel logLevel, bool showlevel, bool showDateTime, bool showLogName, string dateTimeFormat)
+                    : base(instrumentationKey, logName, logLevel, showlevel, showDateTime, showLogName, dateTimeFormat)
+                {
+                    this.owner = owner;
+                }
+
+                protected override void WriteInternal(LogLevel level, object message, Exception exception)
+                {
+                    this.owner.LastLogEntry = new LogEntry(level, message, exception);
+                    base.WriteInternal(level, message, exception);
+                }
+            }
+        }
+
+        public class LogEntry
+        {
+            public LogEntry(LogLevel logLevel, object message, Exception exception)
+            {
+                this.LogLevel = logLevel;
+                this.Message = message;
+                this.Exception = exception;
+            }
+
+            public object Message { get; private set; }
+            public Exception Exception { get; private set; }
+            public LogLevel LogLevel { get; private set; }
+        }
+    }
+}


### PR DESCRIPTION
Contributing to common-logging with Application Insights adapter, which will allow common-logging customers seamlessly route telemetry information to Application Insights.