### PR TITLE
Remove "Warnrmation"

### DIFF
--- a/src/Common.Logging.NLog10/Logging/NLog/NLogLogger.cs
+++ b/src/Common.Logging.NLog10/Logging/NLog/NLogLogger.cs
@@ -1,7 +1,7 @@
 #region License
 
 /*
- * Copyright © 2002-2007 the original author or authors.
+ * Copyright Â© 2002-2007 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -558,7 +558,7 @@ namespace Common.Logging.NLog
         /// <summary>
         /// Log a message with the <see cref="LogLevel.Warn"/> level.
         /// </summary>
-        /// <param name="formatProvider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting Warnrmation.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting Information.</param>
         /// <param name="format">The format of the message object to log.<see cref="string.Format(string,object[])"/> </param>
         /// <param name="args"></param>
         public override void WarnFormat(IFormatProvider formatProvider, string format, params object[] args)
@@ -570,7 +570,7 @@ namespace Common.Logging.NLog
         /// <summary>
         /// Log a message with the <see cref="LogLevel.Warn"/> level.
         /// </summary>
-        /// <param name="formatProvider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting Warnrmation.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting Information.</param>
         /// <param name="format">The format of the message object to log.<see cref="string.Format(string,object[])"/> </param>
         /// <param name="exception">The exception to log.</param>
         /// <param name="args"></param>

--- a/src/Common.Logging.Portable/Logging/Factory/AbstractLogger.cs
+++ b/src/Common.Logging.Portable/Logging/Factory/AbstractLogger.cs
@@ -669,7 +669,7 @@ namespace Common.Logging.Factory
         /// <summary>
         /// Log a message with the <see cref="LogLevel.Warn"/> level.
         /// </summary>
-        /// <param name="formatProvider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting Warnrmation.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting Information.</param>
         /// <param name="format">The format of the message object to log.<see cref="string.Format(string,object[])"/> </param>
         /// <param name="args"></param>
         [StringFormatMethod("format")]
@@ -682,7 +682,7 @@ namespace Common.Logging.Factory
         /// <summary>
         /// Log a message with the <see cref="LogLevel.Warn"/> level.
         /// </summary>
-        /// <param name="formatProvider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting Warnrmation.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting information.</param>
         /// <param name="format">The format of the message object to log.<see cref="string.Format(string,object[])"/> </param>
         /// <param name="exception">The exception to log.</param>
         /// <param name="args"></param>

--- a/src/Common.Logging.Portable/Logging/Simple/NoOpLogger.cs
+++ b/src/Common.Logging.Portable/Logging/Simple/NoOpLogger.cs
@@ -1,7 +1,7 @@
 #region License
 
 /*
- * Copyright © 2002-2009 the original author or authors.
+ * Copyright Â© 2002-2009 the original author or authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -453,7 +453,7 @@ namespace Common.Logging.Simple
         /// <summary>
         /// Ignores message.
         /// </summary>
-        /// <param name="formatProvider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting Warnrmation.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting Information.</param>
         /// <param name="format">The format of the message object to log.<see cref="string.Format(string,object[])"/> </param>
         /// <param name="args">the list of message format arguments</param>
         public void WarnFormat(IFormatProvider formatProvider, string format, params object[] args)
@@ -464,7 +464,7 @@ namespace Common.Logging.Simple
         /// <summary>
         /// Ignores message.
         /// </summary>
-        /// <param name="formatProvider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting Warnrmation.</param>
+        /// <param name="formatProvider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting Information.</param>
         /// <param name="format">The format of the message object to log.<see cref="string.Format(string,object[])"/> </param>
         /// <param name="exception">The exception to log.</param>
         /// <param name="args">the list of message format arguments</param>


### PR DESCRIPTION
It seems some search-and-replace caught the word "Information". This cleans it up.