### PR TITLE
Updated NLogGlobalVariablesContext implementation for NLog41

### DIFF
--- a/src/Common.Logging.NLog41/Common.Logging.NLog41.2010-net40.csproj
+++ b/src/Common.Logging.NLog41/Common.Logging.NLog41.2010-net40.csproj
@@ -78,9 +78,6 @@
     <Compile Include="..\Common.Logging.NLog10\Logging\NLog\NLogLoggerFactoryAdapter.cs">
       <Link>Logging\NLog\NLogLoggerFactoryAdapter.cs</Link>
     </Compile>
-    <Compile Include="..\Common.Logging.NLog20\Logging\NLog\NLogGlobalVariablesContext.cs">
-      <Link>Logging\NLog\NLogGlobalVariablesContext.cs</Link>
-    </Compile>
     <Compile Include="..\Common.Logging.NLog20\Logging\NLog\NLogLogger.VariablesContext.cs">
       <Link>Logging\NLog\NLogLogger.VariablesContext.cs</Link>
     </Compile>
@@ -91,6 +88,7 @@
       <Link>CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="Logging\NLog\NLogGlobalVariablesContext.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/src/Common.Logging.NLog41/Logging/NLog/NLogGlobalVariablesContext.cs
+++ b/src/Common.Logging.NLog41/Logging/NLog/NLogGlobalVariablesContext.cs
@@ -1,0 +1,52 @@
+﻿using ContextNLog = NLog.GlobalDiagnosticsContext;
+
+namespace Common.Logging.NLog
+{
+    /// <summary>
+    /// A global context for logger variables
+    /// </summary>
+    public class NLogGlobalVariablesContext : IVariablesContext
+    {
+        /// <summary>
+        /// Sets the value of a new or existing variable within the global context
+        /// </summary>
+        /// <param name="key">The key of the variable that is to be added</param>
+        /// <param name="value">The value to add</param>
+        public void Set(string key, object value) {
+            ContextNLog.Set(key, value);
+        }
+
+        /// <summary>
+        /// Gets the value of a variable within the global context
+        /// </summary>
+        /// <param name="key">The key of the variable to get</param>
+        /// <returns>The value or null if not found</returns>
+        public object Get(string key) {
+            return ContextNLog.Get(key);
+        }
+
+        /// <summary>
+        /// Checks if a variable is set within the global context
+        /// </summary>
+        /// <param name="key">The key of the variable to check for</param>
+        /// <returns>True if the variable is set</returns>
+        public bool Contains(string key) {
+            return ContextNLog.Contains(key);
+        }
+
+        /// <summary>
+        /// Removes a variable from the global context by key
+        /// </summary>
+        /// <param name="key">The key of the variable to remove</param>
+        public void Remove(string key) {
+            ContextNLog.Remove(key);
+        }
+
+        /// <summary>
+        /// Clears the global context variables
+        /// </summary>
+        public void Clear() {
+            ContextNLog.Clear();
+        }
+    }
+}

--- a/test/Common.Logging.NLog41.Tests/Common.Logging.NLog41.Tests.2010-net40.csproj
+++ b/test/Common.Logging.NLog41.Tests/Common.Logging.NLog41.Tests.2010-net40.csproj
@@ -80,10 +80,8 @@
     <Compile Include="..\Common.Logging.NLog10.Tests\Logger\NLog\NLogLoggerFactoryAdapterTests.cs">
       <Link>Logger\NLog\NLogLoggerFactoryAdapterTests.cs</Link>
     </Compile>
-    <Compile Include="..\Common.Logging.NLog20.Tests\Logger\NLog\NLogLoggerFactoryAdapterVariablesContextTests.cs">
-      <Link>Logger\NLog\NLogLoggerFactoryAdapterVariablesContextTests.cs</Link>
-    </Compile>
     <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="Logger\NLog\NLogLoggerFactoryAdapterVariablesContextTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/test/Common.Logging.NLog41.Tests/Logger/NLog/NLogLoggerFactoryAdapterVariablesContextTests.cs
+++ b/test/Common.Logging.NLog41.Tests/Logger/NLog/NLogLoggerFactoryAdapterVariablesContextTests.cs
@@ -1,0 +1,35 @@
+﻿using Common.Logging;
+using Common.Logging.NLog;
+using NUnit.Framework;
+
+namespace Common.Logger.NLog
+{
+    [TestFixture]
+    public class NLogLoggerFactoryAdapterVariablesContextTests
+    {
+        [Test]
+        public void CheckGlobalVariablesSet()
+        {
+            var a = new NLogLoggerFactoryAdapter((Common.Logging.Configuration.NameValueCollection)null);
+            var testValue = new object();
+
+            a.GetLogger(this.GetType()).GlobalVariablesContext.Set("TestKey", testValue);
+
+            var actualValue = global::NLog.GlobalDiagnosticsContext.GetObject("TestKey");
+
+            Assert.AreEqual(testValue, actualValue);
+        }
+
+        [Test]
+        public void CheckThreadVariablesSet()
+        {
+            var a = new NLogLoggerFactoryAdapter((Common.Logging.Configuration.NameValueCollection)null);
+
+            a.GetLogger(this.GetType()).ThreadVariablesContext.Set("TestKey", "TestValue");
+
+            var actualValue = global::NLog.MappedDiagnosticsContext.Get("TestKey");
+
+            Assert.AreEqual("TestValue", actualValue);
+        }
+    }
+}


### PR DESCRIPTION
From version 4.1 NLog supports object variables (not just strings) from the Global Variable Context / {gdc}.

I've updated the NLogGlobalVariablesContext implementation in the NLog41, so it supports the change.

http://nlog-project.org/2015/08/31/nlog-4-1-0-is-now-available.html
https://github.com/NLog/NLog/wiki/Gdc-Layout-Renderer