### PR TITLE
.NET Core building and packaging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,5 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,30 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "0.1.0",
+    "command": "dotnet",
+    "isShellCommand": true,
+    "args": [],
+    "tasks": [
+        {
+            "taskName": "build",
+            "args":
+             [ 
+                "src/Common.Logging.Core.DotNetCore/project.json",
+                "src/Common.Logging.DotNetCore/project.json"
+             ],
+            "isBuildCommand": true,
+            "showOutput": "silent",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "taskName": "test",
+            "args":
+             [ 
+                "src/Common.Logging.Tests/project.json"
+             ],
+            "showOutput": "silent",
+            "isTestCommand": true
+        }        
+    ]
+}

--- a/Common.Logging.build
+++ b/Common.Logging.build
@@ -237,7 +237,7 @@
     </copy>
     <copy todir="${package.dir}/bin/net/2.0/release" flatten="true">
       <fileset>
-        <include name="**/build/net20/Common.Logging.*/Debug/Common.Logging*.???"/>
+        <include name="**/build/net20/Common.Logging.*/Release/Common.Logging*.???"/>
         <exclude name="**/*Test*"/>
       </fileset>
     </copy>
@@ -249,7 +249,7 @@
     </copy>
     <copy todir="${package.dir}/bin/net/4.0/release" flatten="true">
       <fileset>
-        <include name="**/build/net40/Common.Logging.*/Debug/Common.Logging*.???"/>
+        <include name="**/build/net40/Common.Logging.*/Release/Common.Logging*.???"/>
         <exclude name="**/*Test*"/>
       </fileset>
     </copy>
@@ -261,7 +261,7 @@
     </copy>
     <copy todir="${package.dir}/bin/net/4.5/release" flatten="true">
       <fileset>
-        <include name="**/build/net45/Common.Logging.*/Debug/Common.Logging*.???"/>
+        <include name="**/build/net45/Common.Logging.*/Release/Common.Logging*.???"/>
         <exclude name="**/*Test*"/>
       </fileset>
     </copy>
@@ -570,6 +570,22 @@ ${tool.dir}       : dir for tools
 	<property name="nuget.package.dir" value="${root.dir}/package-nuget" />
 	
 	<call target="clean-nuget-package-dir" />
+
+    <!-- copy .NET Core dlls from build dirs -->
+    <copy todir="${build.dir}/netstandard1.0/Common.Logging.Core/Release">
+      <fileset basedir="src/Common.Logging.Core.DotNetCore/bin/Release/netstandard1.0">
+        <include name="Common.Logging.Core.dll"/>
+        <include name="Common.Logging.Core.pdb"/>
+        <include name="Common.Logging.Core.xml"/>
+      </fileset>
+    </copy>
+    <copy todir="${build.dir}/netstandard1.3/Common.Logging/Release">
+      <fileset basedir="src/Common.Logging.DotNetCore/bin/Release/netstandard1.3">
+        <include name="Common.Logging.dll"/>
+        <include name="Common.Logging.pdb"/>
+        <include name="Common.Logging.xml"/>
+      </fileset>
+    </copy>
 	
 	<foreach item="File" property="filename">
 		<in>
@@ -579,17 +595,15 @@ ${tool.dir}       : dir for tools
 		</in>
 		<do>
 			<echo message="Generating NuGet Package from nuspec file: ${filename}" />  
-
-		
     
-    <exec program="${tool.dir}\NuGet\NuGet.exe" workingdir="${root.dir}" verbose="true">
-      <arg value="pack" />
-      <arg value="${filename}" />
-	  <arg value="-Version" />
-	  <arg value="${nuget.package.version}" />
-	  <arg value="-OutputDirectory" />
-	  <arg value="${nuget.package.dir}" />
-    </exec>
+            <exec program="${tool.dir}\NuGet\NuGet.exe" workingdir="${root.dir}" verbose="true">
+              <arg value="pack" />
+              <arg value="${filename}" />
+              <arg value="-Version" />
+              <arg value="${nuget.package.version}" />
+              <arg value="-OutputDirectory" />
+              <arg value="${nuget.package.dir}" />
+            </exec>
 		</do>
 	</foreach>
 </target>
@@ -605,8 +619,10 @@ ${tool.dir}       : dir for tools
 				<include name="**/*.nuspec" />
 				<!--
 				NOTE: must exclude Common.Logging.Core.nuspec b/c it has no Common.Logging.* deps and so the XPATH expr. won't find a match in that case and so would fail the XMLPOKE operation otherwise
+                      and Common.Logging as it uses different syntax
 				-->
 				<exclude name="**/Common.Logging.Core.nuspec" />
+				<exclude name="**/Common.Logging.nuspec" />
 			</items>
 		</in>
 		<do>
@@ -618,6 +634,22 @@ ${tool.dir}       : dir for tools
 			</xmlpoke>
 		</do>
 	</foreach>
+    <!-- another round to poke values that are in grouped form (netstandard etc) -->
+	<foreach item="File" property="filename">
+		<in>
+			<items basedir="${root.dir}/src/">
+				<include name="**/Common.Logging.nuspec" />
+			</items>
+		</in>
+		<do>
+			<echo message="Processing nuspec file: ${filename}" />
+			<xmlpoke file="${filename}" xpath="/n:package/n:metadata/n:dependencies/n:group/n:dependency[@id='Common.Logging' or @id='Common.Logging.Core' or @id='Common.Logging.Portable']/@version" value="${nuget.package.version}">
+				<namespaces>
+					<namespace prefix="n" uri="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd" />
+				</namespaces>
+			</xmlpoke>
+		</do>
+	</foreach>    
 </target>
 
 

--- a/src/Common.Logging.Core.DotNetCore/Common.Logging.Core.DotNetCore.xproj
+++ b/src/Common.Logging.Core.DotNetCore/Common.Logging.Core.DotNetCore.xproj
@@ -8,8 +8,6 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>b7a3507b-7346-4fca-8b6f-9405e50a6bd4</ProjectGuid>
     <RootNamespace>Common.Logging.Core</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\Build\DotNetCore</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\Build\DotNetCore</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/Common.Logging.Core.DotNetCore/project.json
+++ b/src/Common.Logging.Core.DotNetCore/project.json
@@ -1,18 +1,20 @@
-﻿{
+{
   "version": "3.4.0-*",
-  "description": "Common.Logging.Core.DotNetCore",
   "buildOptions": {
+    "keyFile": "../../Common.Net.snk",
     "define": [ "PORTABLE", "DOTNETCORE" ],
-    "compile": [ "../Common.Logging.Core/**/*.cs", "../CommonAssemblyInfo.cs" ]
+    "compile": {
+      "include": [ "../Common.Logging.Core/**/*.cs", "../CommonAssemblyInfo.cs" ]
+    },
+    "debugType": "portable",
+    "xmlDoc": true,
+    "outputName": "Common.Logging.Core"
   },
   "frameworks": {
-    "dotnet": { }
-  },
-  "dependencies": {
-    "Microsoft.CSharp": "4.0.0",
-    "System.Collections": "4.0.10",
-    "System.Linq": "4.0.0",
-    "System.Runtime": "4.0.20",
-    "System.Threading": "4.0.10"
+    "netstandard1.0": {
+      "dependencies": {
+        "Microsoft.CSharp": "4.0.1"
+      }
+    }
   }
 }

--- a/src/Common.Logging.Core/Common.Logging.Core.nuspec
+++ b/src/Common.Logging.Core/Common.Logging.Core.nuspec
@@ -11,16 +11,23 @@
     <description>Common.Logging.Core contains the portable (PCL) implementation of the Common.Logging low-level abstractions common to all other Common.Logging packages.</description>
 	<tags>PCL Common.Logging.Portable Common.Logging.Core logging log Common.Logging</tags>
     <language>en-US</language>
+    <dependencies>
+      <group targetFramework=".NETStandard1.0">
+        <dependency id="Microsoft.CSharp" version="[4.0.1, )" />
+      </group>
+    </dependencies>
   </metadata>
   <files>
     <file src="..\..\build\portable\Common.Logging.Core\Release\Common.Logging.Core.dll" target="lib\portable-win+net40+sl40+wp7+wpa81" />
     <file src="..\..\build\portable\Common.Logging.Core\Release\Common.Logging.Core.pdb" target="lib\portable-win+net40+sl40+wp7+wpa81" />
     <file src="..\..\build\portable\Common.Logging.Core\Release\Common.Logging.Core.xml" target="lib\portable-win+net40+sl40+wp7+wpa81" />
+
     <file src="..\..\build\portable\Common.Logging.Core\Release\Common.Logging.Core.dll" target="lib\net40" />
     <file src="..\..\build\portable\Common.Logging.Core\Release\Common.Logging.Core.pdb" target="lib\net40" />
-    <file src="..\..\build\portable\Common.Logging.Portable\Release\Common.Logging.Core.xml" target="lib\net40" />
-    <file src="..\..\build\net20\Common.Logging.Portable\Release\Common.Logging.Core.dll" target="lib\net35" />
-    <file src="..\..\build\net20\Common.Logging.Portable\Release\Common.Logging.Core.pdb" target="lib\net35" />
-    <file src="..\..\build\net20\Common.Logging.Portable\Release\Common.Logging.Core.xml" target="lib\net35" />
+    <file src="..\..\build\portable\Common.Logging.Core\Release\Common.Logging.Core.xml" target="lib\net40" />
+
+    <file src="..\..\build\netstandard1.0\Common.Logging.Core\Release\Common.Logging.Core.dll" target="lib\netstandard1.0" />
+    <file src="..\..\build\netstandard1.0\Common.Logging.Core\Release\Common.Logging.Core.pdb" target="lib\netstandard1.0" />
+    <file src="..\..\build\netstandard1.0\Common.Logging.Core\Release\Common.Logging.Core.xml" target="lib\netstandard1.0" />
   </files>  
 </package>

--- a/src/Common.Logging.DotNetCore/Common.Logging.DotNetCore.xproj
+++ b/src/Common.Logging.DotNetCore/Common.Logging.DotNetCore.xproj
@@ -8,8 +8,6 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>62d1bd54-10d9-4f6a-bf5f-5447a55c987f</ProjectGuid>
     <RootNamespace>Common.Logging</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\Build\DotNetCore</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\Build\DotNetCore</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/Common.Logging.DotNetCore/project.json
+++ b/src/Common.Logging.DotNetCore/project.json
@@ -1,21 +1,32 @@
 {
   "version": "3.4.0-*",
-  "description": "Common.Logging.DotNetCore",
   "buildOptions": {
+    "keyFile": "../../Common.Net.snk",
     "define": [ "PORTABLE", "DOTNETCORE" ],
-    "compile": [ "../Common.Logging.Portable/**/*.cs", "../CommonAssemblyInfo.cs" ],
-    "compileExclude": [ "../Common.Logging.Portable/Logging/Factory/ResharperAnnotation.cs" ]
+    "compile": {
+      "include": [ "../Common.Logging.Portable/**/*.cs", "../CommonAssemblyInfo.cs" ],
+      "exclude": [ "../Common.Logging.Portable/Logging/Factory/ResharperAnnotation.cs" ]
+    },
+    "debugType": "portable",
+    "xmlDoc": true,
+    "outputName": "Common.Logging"
   },
   "dependencies": {
-    "Common.Logging.Core.DotNetCore": "3.4.0-*",
-    "Microsoft.CSharp": "4.0.0",
-    "System.Collections": "4.0.10",
-    "System.Linq": "4.0.0",
-    "System.Runtime": "4.0.20",
-    "System.Threading": "4.0.10"
+    "Common.Logging.Core.DotNetCore": {
+      "target": "project"
+    }
   },
   "frameworks": {
-    "dotnet": { }
+    "netstandard1.3": {
+      "dependencies": {
+        "Microsoft.CSharp": "4.0.1",
+        "System.Collections": "4.0.11",
+        "System.Diagnostics.Debug": "4.0.11",
+        "System.Globalization": "4.0.11",
+        "System.Reflection.TypeExtensions": "4.1.0",
+        "System.Runtime.Extensions": "4.1.0",
+        "System.Threading": "4.0.11"
+      }
+    }
   }
-  
 }

--- a/src/Common.Logging.ETWLogger/Common.Logging.ETWLogger.2010-net40.csproj
+++ b/src/Common.Logging.ETWLogger/Common.Logging.ETWLogger.2010-net40.csproj
@@ -45,7 +45,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Common.Logging.MultipleLogger/Common.Logging.MultipleLogger.2010-net40.csproj
+++ b/src/Common.Logging.MultipleLogger/Common.Logging.MultipleLogger.2010-net40.csproj
@@ -39,7 +39,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Common.Logging/Common.Logging.nuspec
+++ b/src/Common.Logging/Common.Logging.nuspec
@@ -13,15 +13,37 @@
     <tags>logging log Common.Logging</tags>
     <language>en-US</language>
     <dependencies>
-      <dependency id="Common.Logging.Core" version="3.4-Alpha1" />
-    </dependencies>
+      <group targetFramework="net35">
+        <dependency id="Common.Logging.Core" version="3.4-Alpha1" />
+      </group>
+      <group targetFramework="net40">
+        <dependency id="Common.Logging.Core" version="3.4-Alpha1" />
+      </group>
+      <group targetFramework=".NETStandard1.3">
+        <dependency id="Microsoft.CSharp" version="[4.0.1, )" />
+        <dependency id="System.Collections" version="[4.0.11, )" />
+        <dependency id="System.Diagnostics.Debug" version="[4.0.11, )" />
+        <dependency id="System.Globalization" version="[4.0.11, )" />
+        <dependency id="System.Reflection.TypeExtensions" version="[4.1.0, )" />
+        <dependency id="System.Runtime.Extensions" version="[4.1.0, )" />
+        <dependency id="System.Threading" version="[4.0.11, )" />
+        <dependency id="Common.Logging.Core" version="[3.4.0, )" />
+     </group>
+    </dependencies>  
+
   </metadata>
   <files>
     <file src="..\..\build\net20\Common.Logging\Release\Common.Logging.dll" target="lib\net35" />
     <file src="..\..\build\net20\Common.Logging\Release\Common.Logging.pdb" target="lib\net35" />
     <file src="..\..\build\net20\Common.Logging\Release\Common.Logging.xml" target="lib\net35" />
+
     <file src="..\..\build\net40\Common.Logging\Release\Common.Logging.dll" target="lib\net40" />
     <file src="..\..\build\net40\Common.Logging\Release\Common.Logging.pdb" target="lib\net40" />
     <file src="..\..\build\net40\Common.Logging\Release\Common.Logging.xml" target="lib\net40" />
+
+    <file src="..\..\build\netstandard1.3\Common.Logging\Release\Common.Logging.dll" target="lib\netstandard1.3" />
+    <file src="..\..\build\netstandard1.3\Common.Logging\Release\Common.Logging.pdb" target="lib\netstandard1.3" />
+    <file src="..\..\build\netstandard1.3\Common.Logging\Release\Common.Logging.xml" target="lib\netstandard1.3" />
   </files>
+  
 </package>

--- a/test/Common.Logging.ETWLogger.Tests/Common.Logging.ETWLogger.Tests.2010-net40.csproj
+++ b/test/Common.Logging.ETWLogger.Tests/Common.Logging.ETWLogger.Tests.2010-net40.csproj
@@ -49,7 +49,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Common.Logging.MultipleLogger.Tests/Common.Logging.MultipleLogger.Tests.2010-net40.csproj
+++ b/test/Common.Logging.MultipleLogger.Tests/Common.Logging.MultipleLogger.Tests.2010-net40.csproj
@@ -40,7 +40,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
* tweak build to output netstandard1.3 binaries
* pack .NET Core dlls to main packages (copy from src dir to build dir before packaging), one pitfall now is that snk file is always required as project.jsons reference it to achieve signed build
* nuspec files tweaked to contain dependency information that would be provided automatically with dotnet pack
* fix ETW project references
* add Visual Studio Code tasks for building the .NET Core version