### PR TITLE
Allow configuration using POCOs for .Net Core

### DIFF
--- a/src/Common.Logging.Portable/Common.Logging.Portable.2010.csproj
+++ b/src/Common.Logging.Portable/Common.Logging.Portable.2010.csproj
@@ -76,6 +76,9 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Logging\ConfigurationException.cs" />
+    <Compile Include="Logging\Configuration\FactoryAdapterConfiguration.cs" />
+    <Compile Include="Logging\Configuration\LogConfiguration.cs" />
+    <Compile Include="Logging\Configuration\LogConfigurationReader.cs" />
     <Compile Include="Logging\Configuration\NameValueCollection.cs" />
     <Compile Include="Logging\Configuration\NameValueCollectionHelper.cs" />
     <Compile Include="Logging\Factory\AbstractLogger.cs" />

--- a/src/Common.Logging.Portable/Logging/Configuration/FactoryAdapterConfiguration.cs
+++ b/src/Common.Logging.Portable/Logging/Configuration/FactoryAdapterConfiguration.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Common.Logging.Configuration
+{
+    /// <summary>
+    /// JSON serializable object representing the configuration of the <see cref="ILoggerFactoryAdapter"/>.
+    /// </summary>
+    public class FactoryAdapterConfiguration
+    {
+        /// <summary>
+        /// Fully qualified type name of a class implementing <see cref="ILoggerFactoryAdapter"/>.
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Optional set of arguments for the constructor of the class specified in <see cref="Type"/>.
+        /// </summary>
+        public NameValueCollection Arguments { get; set; }
+    }
+}

--- a/src/Common.Logging.Portable/Logging/Configuration/LogConfiguration.cs
+++ b/src/Common.Logging.Portable/Logging/Configuration/LogConfiguration.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Common.Logging.Configuration
+{
+    /// <summary>
+    /// JSON serializable object representing the configuration of the logging subsystem.
+    /// May be passed to <see cref="LogManager.Configure"/>.
+    /// </summary>
+    public class LogConfiguration
+    {
+        /// <summary>
+        /// Defines the <see cref="ILoggerFactoryAdapter"/> used by the logging subsystem.
+        /// </summary>
+        public FactoryAdapterConfiguration FactoryAdapter { get; set; }
+    }
+}

--- a/src/Common.Logging.Portable/Logging/Configuration/LogConfigurationReader.cs
+++ b/src/Common.Logging.Portable/Logging/Configuration/LogConfigurationReader.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Common.Logging.Configuration
+{
+    /// <summary>
+    /// Implementation of <see cref="IConfigurationReader"/> that uses a supplied
+    /// <see cref="LogConfiguration"/> object.
+    /// </summary>
+    /// <author>Brant Burnett</author>
+    public class LogConfigurationReader : IConfigurationReader
+    {
+        private readonly LogConfiguration _configuration;
+
+        /// <summary>
+        /// Creates a new <see cref="LogConfigurationReader"/> given a <see cref="LogConfiguration"/> object.
+        /// </summary>
+        /// <param name="configuration"><see cref="LogConfiguration"/> to be parsed.</param>
+        public LogConfigurationReader(LogConfiguration configuration)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException("configuration");
+            }
+
+            _configuration = configuration;
+        }
+
+        /// <summary>
+        /// Returns a <see cref="LogSetting"/> based on the <see cref="LogConfiguration"/> supplied
+        /// in the constructor.
+        /// </summary>
+        /// <param name="sectionName">This parameter is not used in this implementation.</param>
+        /// <returns><see cref="LogSetting"/> based on the supplied configuration.</returns>
+        public object GetSection(string sectionName)
+        {
+            if (_configuration.FactoryAdapter == null)
+            {
+                throw new ConfigurationException("LogConfiguration.FactoryAdapter is required.");
+            }
+            if (string.IsNullOrEmpty(_configuration.FactoryAdapter.Type))
+            {
+                throw new ConfigurationException("LogConfiguration.FactoryAdapter.Type is required.");
+            }
+
+            Type factoryType;
+            try
+            {
+                factoryType = Type.GetType(_configuration.FactoryAdapter.Type, true);
+            }
+            catch (Exception e)
+            {
+                throw new ConfigurationException
+                  ("Unable to create type '" + _configuration.FactoryAdapter.Type + "'"
+                    , e
+                  );
+            }
+
+            return new LogSetting(factoryType, _configuration.FactoryAdapter.Arguments);
+        }
+    }
+}

--- a/src/Common.Logging.Portable/Logging/LogManager.cs
+++ b/src/Common.Logging.Portable/Logging/LogManager.cs
@@ -187,6 +187,28 @@ namespace Common.Logging
 
 
         /// <summary>
+        /// Reset the <see cref="Common.Logging" /> infrastructure to the provided configuration.
+        /// </summary>
+        /// <remarks>
+        /// <b>Note:</b><see cref="ILog"/> instances already handed out from this LogManager are not(!) affected.
+        /// Configuring LogManager only affects new instances being handed out.
+        /// </remarks>
+        /// <param name="configuration">
+        /// the <see cref="LogConfiguration"/> containing settings for
+        /// re-initializing the LogManager.
+        /// </param>
+        public static void Configure(LogConfiguration configuration)
+        {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException("configuration");
+            }
+
+            Reset(new LogConfigurationReader(configuration));
+        }
+
+
+        /// <summary>
         /// Gets or sets the adapter.
         /// </summary>
         /// <value>The adapter.</value>

--- a/src/Common.Logging/Common.Logging.2010-net40.csproj
+++ b/src/Common.Logging/Common.Logging.2010-net40.csproj
@@ -83,6 +83,15 @@
     <Compile Include="..\Common.Logging.Portable\Logging\Configuration\DefaultConfigurationReader.cs">
       <Link>Logging\Configuration\DefaultConfigurationReader.cs</Link>
     </Compile>
+    <Compile Include="..\Common.Logging.Portable\Logging\Configuration\FactoryAdapterConfiguration.cs">
+      <Link>Logging\Configuration\FactoryAdapterConfiguration.cs</Link>
+    </Compile>
+    <Compile Include="..\Common.Logging.Portable\Logging\Configuration\LogConfiguration.cs">
+      <Link>Logging\Configuration\LogConfiguration.cs</Link>
+    </Compile>
+    <Compile Include="..\Common.Logging.Portable\Logging\Configuration\LogConfigurationReader.cs">
+      <Link>Logging\Configuration\LogConfigurationReader.cs</Link>
+    </Compile>
     <Compile Include="..\Common.Logging.Portable\Logging\Configuration\LogSetting.cs">
       <Link>Logging\Configuration\LogSetting.cs</Link>
     </Compile>

--- a/test/Common.Logging.Tests/Common.Logging.Tests.2010-net40.csproj
+++ b/test/Common.Logging.Tests/Common.Logging.Tests.2010-net40.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Logging\ConfigurationSectionHandlerTests.cs" />
     <Compile Include="Logging\Configuration\ArgUtilsTests.cs" />
     <Compile Include="Logging\Configuration\DefaultConfigurationReaderTests.cs" />
+    <Compile Include="Logging\Configuration\LogConfigurationReaderTests.cs" />
     <Compile Include="Logging\LoggingExceptionTests.cs" />
     <Compile Include="Logging\LogManagerTests.cs" />
     <Compile Include="Logging\MissingCtorFactoryAdapter.cs" />

--- a/test/Common.Logging.Tests/Logging/Configuration/LogConfigurationReaderTests.cs
+++ b/test/Common.Logging.Tests/Logging/Configuration/LogConfigurationReaderTests.cs
@@ -1,0 +1,175 @@
+#region License
+
+/*
+ * Copyright 2002-2009 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#endregion
+
+using System;
+using NUnit.Framework;
+
+namespace Common.Logging.Configuration
+{
+    /// <summary>
+    /// </summary>
+    /// <author>Brant Burnett</author>
+    [TestFixture]
+    public class LogConfigurationReaderTests
+    {
+        [Test]
+        public void ctor_NullConfiguration_ThrowsArgumentNull()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() => {
+                var reader = new LogConfigurationReader(null);
+            });
+
+            Assert.AreEqual("configuration", ex.ParamName);
+        }
+
+        [Test]
+        public void GetSection_NullFactoryAdapter_ThrowsConfigurationException()
+        {
+            var config = new LogConfiguration();
+
+            var reader = new LogConfigurationReader(config);
+
+            Assert.Throws<ConfigurationException>(() => reader.GetSection(null));
+        }
+
+        [Test]
+        public void GetSection_NullFactoryAdapterType_ThrowsConfigurationException()
+        {
+            var config = new LogConfiguration()
+            {
+                FactoryAdapter = new FactoryAdapterConfiguration()
+            };
+
+            var reader = new LogConfigurationReader(config);
+
+            Assert.Throws<ConfigurationException>(() => reader.GetSection(null));
+        }
+
+        [Test]
+        public void GetSection_EmptyFactoryAdapterType_ThrowsConfigurationException()
+        {
+            var config = new LogConfiguration()
+            {
+                FactoryAdapter = new FactoryAdapterConfiguration()
+                {
+                    Type = ""
+                }
+            };
+
+            var reader = new LogConfigurationReader(config);
+
+            Assert.Throws<ConfigurationException>(() => reader.GetSection(null));
+        }
+
+        [Test]
+        public void GetSection_BadFactoryAdapterType_ThrowsConfigurationException()
+        {
+            var config = new LogConfiguration()
+            {
+                FactoryAdapter = new FactoryAdapterConfiguration()
+                {
+                    Type = "SomeType, SomeAssembly"
+                }
+            };
+
+            var reader = new LogConfigurationReader(config);
+
+            Assert.Throws<ConfigurationException>(() => reader.GetSection(null));
+        }
+
+        [Test]
+        public void GetSection_GoodFactoryAdapterType_ReturnsLogSettingWithType()
+        {
+            var config = new LogConfiguration()
+            {
+                FactoryAdapter = new FactoryAdapterConfiguration()
+                {
+                    Type = typeof(FakeFactoryAdapter).AssemblyQualifiedName
+                }
+            };
+
+            var reader = new LogConfigurationReader(config);
+
+            var result = reader.GetSection(null) as LogSetting;
+
+            Assert.NotNull(result);
+            Assert.AreEqual(typeof(FakeFactoryAdapter), result.FactoryAdapterType);
+        }
+
+        [Test]
+        public void GetSection_NoArguments_ReturnsLogSettingWithNullArguments()
+        {
+            var config = new LogConfiguration()
+            {
+                FactoryAdapter = new FactoryAdapterConfiguration()
+                {
+                    Type = typeof(FakeFactoryAdapter).AssemblyQualifiedName
+                }
+            };
+
+            var reader = new LogConfigurationReader(config);
+
+            var result = reader.GetSection(null) as LogSetting;
+
+            Assert.NotNull(result);
+            Assert.IsNull(result.Properties);
+        }
+
+        [Test]
+        public void GetSection_HasArguments_ReturnsLogSettingWithArguments()
+        {
+            var config = new LogConfiguration()
+            {
+                FactoryAdapter = new FactoryAdapterConfiguration()
+                {
+                    Type = typeof(FakeFactoryAdapter).AssemblyQualifiedName,
+                    Arguments = new NameValueCollection
+                    {
+                        { "arg1", "value1" }
+                    }
+                }
+            };
+
+            var reader = new LogConfigurationReader(config);
+
+            var result = reader.GetSection(null) as LogSetting;
+
+            Assert.NotNull(result);
+            Assert.AreEqual("value1", result.Properties["arg1"]);
+        }
+
+        #region Helpers
+
+        public class FakeFactoryAdapter : ILoggerFactoryAdapter
+        {
+            public ILog GetLogger(Type type)
+            {
+                throw new NotImplementedException();
+            }
+
+            public ILog GetLogger(string key)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+#endregion
+    }
+}

--- a/test/Common.Logging.Tests/Logging/LogManagerTests.cs
+++ b/test/Common.Logging.Tests/Logging/LogManagerTests.cs
@@ -117,6 +117,42 @@ namespace Common.Logging
         }
 
         [Test]
+        public void ConfigureFromLogConfiguration()
+        {
+            ILog log;
+
+            // accepts simple factory adapter
+            LogManager.Configure(new LogConfiguration() {
+                FactoryAdapter = new FactoryAdapterConfiguration()
+                {
+                    Type = typeof(TraceLoggerFactoryAdapter).FullName
+                }
+            });
+            log = LogManager.GetLogger<LogManagerTests>();
+            Assert.AreEqual(typeof(TraceLogger), log.GetType());
+
+            // accepts parameterized factory adapter
+            LogManager.Configure(new LogConfiguration()
+            {
+                FactoryAdapter = new FactoryAdapterConfiguration()
+                {
+                    Type = typeof(DebugLoggerFactoryAdapter).FullName,
+                    Arguments = new NameValueCollection
+                    {
+                        { "level", "All" },
+                        { "showDateTime", "true" },
+                        { "showLogName", "true"},
+                        { "showLevel", "true"},
+                        { "dateTimeFormat", "yyyy/MM/dd hh:tt:ss.fff" }
+                    }
+                }
+            });
+            log = LogManager.GetLogger<LogManagerTests>();
+            Assert.AreEqual(typeof(DebugOutLogger), log.GetType());
+            Assert.AreEqual(true, ((DebugOutLogger) log).ShowLogName);
+        }
+
+        [Test]
         public void ConfigureFromStandaloneConfig()
         {
             const string xml =


### PR DESCRIPTION
* Create POCO classes that can be deserilized from JSON
* Add Configure method to LogManager configure using POCOs
* Add tests for new configuration method

Notes
-------
This approach to configuration in .Net Core will still require some code to be included in application startup.  However, this is consistent with .Net Core design principles.  These POCOs simply makes it easy to either declare the configuration directly in code, or to read the configuration from JSON or any other configuration approach using the Microsoft.Extensions.Configuration system.

Also, note that this new configuration approach will be available to all consumers, not just .Net Core.  Any new project has the option to use this configuration method instead of the original XML approach.