### PR TITLE
Update ApplicationInsights quickstart

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,16 +77,16 @@ The app config should then have a common logging section like below. Be sure to 
 ```
 
 ## Application Insights Quickstart
-There are different packages for each major Application Insights version. Install the correct package for your referenced Application Insights version. This example installs the adapter for Application Insights v0.17:
+There are different packages for each major Application Insights version. Install the correct package for your referenced Application Insights version. This example installs the adapter for Application Insights v2.4.0:
 
-    PM> Install-Package Microsoft.ApplicationInsights -Version 0.17.0
+    PM> Install-Package Microsoft.ApplicationInsights -Version 2.4.0
 
 The app config should then have an Application Insights section like below. Be sure to set the InstrumentationKey with your InstrumentationKey retrieved from Application Insights portal https://portal.azure.com.
 
 ```xml
 <common>
     <logging>
-      <factoryAdapter type="Common.Logging.ApplicationInsights.ApplicationInsightsLoggerFactoryAdapter, Common.Logging.ApplicationInsights">
+      <factoryAdapter type="Common.Logging.ApplicationInsights.ApplicationInsightsLoggerFactoryAdapter, Common.Logging.ApplicationInsights240">
     	<arg key="InstrumentationKey" value="[YOUR APPLICATION INSIGHTS INSTRUMENTATION KEY]" />
       </factoryAdapter>
     </logging>


### PR DESCRIPTION
Hi, I noticed that the quickstart for ApplicationInsights was 1. out of date and 2. not quite correct. I updated the versions to the latest AI (2.4.0) and added that you need to specify '240' at the end of the `factoryAdapter` config.