### PR TITLE
Added reading configuration from App.config/web.config for .NET Core

### DIFF
--- a/src/Common.Logging.Portable/Logging/Configuration/ArgUtils.cs
+++ b/src/Common.Logging.Portable/Logging/Configuration/ArgUtils.cs
@@ -106,7 +106,7 @@ namespace Common.Logging.Configuration
         /// <seealso cref="Coalesce{T}"/>
         public static string Coalesce(params string[] values)
         {
-            return Coalesce(delegate(string v) { return !string.IsNullOrEmpty(v); }, values);
+            return Coalesce(delegate (string v) { return !string.IsNullOrEmpty(v); }, values);
         }
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace Common.Logging.Configuration
 
             if (predicate == null)
             {
-                predicate = delegate(T v) { return v != null; };
+                predicate = delegate (T v) { return v != null; };
             }
 
             for (int i = 0; i < values.Length; i++)
@@ -158,7 +158,6 @@ namespace Common.Logging.Configuration
                 throw new ArgumentException(string.Format("Type '{0}' is not an enum type", typeof(T).FullName));
             }
 
-            
             try
             {
                 // If a string is specified then try to parse and return it
@@ -264,7 +263,11 @@ namespace Common.Logging.Configuration
                 throw new ArgumentNullException("valType");
             }
 
+#if DOTNETCORE
+            if (!typeof(T).GetTypeInfo().IsAssignableFrom(valType.GetTypeInfo()))
+#else
             if (!typeof(T).IsAssignableFrom(valType))
+#endif
             {
 #if PORTABLE
                 throw new ArgumentOutOfRangeException(paramName, string.Format(messageFormat, args));

--- a/src/Common.Logging.Portable/Logging/Configuration/DefaultConfigurationReader.cs
+++ b/src/Common.Logging.Portable/Logging/Configuration/DefaultConfigurationReader.cs
@@ -45,8 +45,19 @@ namespace Common.Logging.Configuration
         /// </remarks>
         public object GetSection(string sectionName)
         {
-#if DOTNETCORE     // No System.Configuration in DotNetCore, replace with something DotNetCore-specific?
-            return null;
+#if DOTNETCORE     
+            const string configManager40 = "System.Configuration.ConfigurationManager, System.Configuration.ConfigurationManager";
+            var configurationManager = Type.GetType(configManager40);
+            if (configurationManager == null)
+            {
+                return null;
+            }
+
+            var getSection = configurationManager.GetMethod("GetSection");
+            if (getSection == null)
+                throw new PlatformNotSupportedException("Could not find System.Configuration.ConfigurationManager.GetSection method");
+
+            return getSection.Invoke(null, new[] { sectionName });
 #else
 #if PORTABLE
             // We should instead look for something implementing 

--- a/src/Common.Logging.Portable/Logging/Configuration/NameValueCollectionHelper.cs
+++ b/src/Common.Logging.Portable/Logging/Configuration/NameValueCollectionHelper.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace Common.Logging.Configuration
 {
 
-#if !PORTABLE || NET20
+#if !PORTABLE || NET20 || DOTNETCORE
     /// <summary>
     /// Helper class for working with NameValueCollection
     /// </summary>


### PR DESCRIPTION
The change is necessary when classic .NET Framework is using .NET Core version of Common.Logging.
It would be best to check in runtime if classic .NET Framework application is running. However I haven't found a good method to do so and this change doesn't harm pure .NET Core applications.